### PR TITLE
Add Speed Detections

### DIFF
--- a/src/Bavfalcon9/Mavoric/Cheat/Movement/Speed.php
+++ b/src/Bavfalcon9/Mavoric/Cheat/Movement/Speed.php
@@ -85,7 +85,7 @@ class Speed extends Cheat {
         
 
         if($dX > $expected){
-            if($this->lastDistance[$player->getName()][0] >= $expected){
+            if($this->lastDistance[$player->getName()][0] > $expected){
                 $this->increment($player->getName(), 1);
                 $this->notifyAndIncrement($player, 2, 1, [
                     "TPS" => $player->getServer()->getTicksPerSecond(),
@@ -95,7 +95,7 @@ class Speed extends Cheat {
         }
 
         if($dZ > $expected){
-            if($this->lastDistance[$player->getName()][1] >= $expected){
+            if($this->lastDistance[$player->getName()][1] > $expected){
                 $this->increment($player->getName(), 1);
                 $this->notifyAndIncrement($player, 2, 1, [
                     "TPS" => $player->getServer()->getTicksPerSecond(),

--- a/src/Bavfalcon9/Mavoric/Cheat/Movement/Speed.php
+++ b/src/Bavfalcon9/Mavoric/Cheat/Movement/Speed.php
@@ -18,18 +18,100 @@
 namespace Bavfalcon9\Mavoric\Cheat\Movement;
 
 use pocketmine\Player;
+use pocketmine\Server;
 use pocketmine\event\Listener;
 use pocketmine\event\player\PlayerMoveEvent;
+use pocketmine\math\Vector3;
 use Bavfalcon9\Mavoric\Mavoric;
 use Bavfalcon9\Mavoric\Cheat\Cheat;
 use Bavfalcon9\Mavoric\Cheat\CheatManager;
 
+function square($x) : int{
+    return $x * $x;
+}
+
 class Speed extends Cheat {
+
+    private $lastDistance = [];
+    private $lastTime = [];
+
     public function __construct(Mavoric $mavoric, int $id = -1) {
-        parent::__construct($mavoric, "Speed", "Movement", $id, false);
+        parent::__construct($mavoric, "Speed", "Movement", $id, true);
     }
 
-    public function onPlayerMove(PlayerMoveEvent $ev): void {
+    public function onPlayerMove(PlayerMoveEvent $event): void {
 
+        $player = $event->getPlayer();
+
+        $from = $event->getFrom();
+        $to = $event->getTo();
+        
+        $dX = $to->x - $from->x;
+        $dZ = $to->z - $from->z;
+
+        if(!isset($this->lastDistance[$player->getName()])){
+            $this->lastDistance[$player->getName()] = [
+                0 => $dX,
+                1 => $dZ
+            ];
+            return;
+        }
+        
+        if(!isset($this->lastTime[$player->getName()])) $this->lastTime[$player->getName()] = microtime(true);
+
+        $expected = 0.82567;
+        if($player->getEffect(1) !== null){
+            if($player->getEffect(1)->getEffectLevel() != 0){
+                $expected = 0.82567 + ($player->getEffect(1)->getEffectLevel() * 0.2) * 0.82567;
+            }
+        }
+
+        //if the last moved tick was 2 ticks ago
+        $currentTime = microtime(true);
+        $time = $currentTime - $this->lastTime[$player->getName()];
+        $ticks = round($time * 20, 2);
+        if($ticks >= 2){
+            if($player->getEffect(1) !== null){
+                if($player->getEffect(1)->getEffectLevel() != 0){
+                    $expected = 0.82567 + ($player->getEffect(1)->getEffectLevel() * 0.2) * 0.82567;
+                }
+            } else {
+                $expected = 0.82567 * $ticks;
+            }
+        }
+
+        $speeds = [$dX, $dZ];
+        print_r("Expected speed is: " . $expected . "\n");
+        
+
+        if($dX > $expected){
+            if($this->lastDistance[$player->getName()][0] >= $expected){
+                $this->increment($player->getName(), 1);
+                $this->notifyAndIncrement($player, 2, 1, [
+                    "TPS" => $player->getServer()->getTicksPerSecond(),
+                    "Ping" => $player->getPing()
+                ]);
+            }
+        }
+
+        if($dZ > $expected){
+            if($this->lastDistance[$player->getName()][1] >= $expected){
+                $this->increment($player->getName(), 1);
+                $this->notifyAndIncrement($player, 2, 1, [
+                    "TPS" => $player->getServer()->getTicksPerSecond(),
+                    "Ping" => $player->getPing()
+                ]);
+            }
+        }
+
+        $this->lastDistance[$player->getName()] = [
+            0 => $dX,
+            1 => $dZ
+        ];
+
+        unset($this->lastTime[$player->getName()]);
+        $this->lastTime[$player->getName()] = microtime(true);
+        
     }
+
 }

--- a/src/Bavfalcon9/Mavoric/Cheat/Movement/Speed.php
+++ b/src/Bavfalcon9/Mavoric/Cheat/Movement/Speed.php
@@ -26,10 +26,6 @@ use Bavfalcon9\Mavoric\Mavoric;
 use Bavfalcon9\Mavoric\Cheat\Cheat;
 use Bavfalcon9\Mavoric\Cheat\CheatManager;
 
-function square($x) : int{
-    return $x * $x;
-}
-
 class Speed extends Cheat {
 
     private $lastDistance = [];
@@ -82,10 +78,11 @@ class Speed extends Cheat {
 
         $speeds = [$dX, $dZ];
         print_r("Expected speed is: " . $expected . "\n");
+        print_r("Speed Given: [DX: " . $dX . " | DZ: " . $dz . "]\n");
         
 
-        if($dX > $expected){
-            if($this->lastDistance[$player->getName()][0] > $expected){
+        if($dX > $expected || $dX < -$expected){
+            if($this->lastDistance[$player->getName()][0] >= $expected){
                 $this->increment($player->getName(), 1);
                 $this->notifyAndIncrement($player, 2, 1, [
                     "TPS" => $player->getServer()->getTicksPerSecond(),
@@ -94,8 +91,8 @@ class Speed extends Cheat {
             }
         }
 
-        if($dZ > $expected){
-            if($this->lastDistance[$player->getName()][1] > $expected){
+        if($dZ > $expected || $dZ < -$expected){
+            if($this->lastDistance[$player->getName()][1] >= $expected){
                 $this->increment($player->getName(), 1);
                 $this->notifyAndIncrement($player, 2, 1, [
                     "TPS" => $player->getServer()->getTicksPerSecond(),

--- a/src/Bavfalcon9/Mavoric/Cheat/Movement/Speed.php
+++ b/src/Bavfalcon9/Mavoric/Cheat/Movement/Speed.php
@@ -78,7 +78,7 @@ class Speed extends Cheat {
 
         $speeds = [$dX, $dZ];
         print_r("Expected speed is: " . $expected . "\n");
-        print_r("Speed Given: [DX: " . $dX . " | DZ: " . $dz . "]\n");
+        print_r("Speed Given: [DX: " . $dX . " | DZ: " . $dZ . "]\n");
         
 
         if($dX > $expected || $dX < -$expected){


### PR DESCRIPTION
This speed detection will have an expected travel distance, and if it goes above this, it will mark the player.

Taking into account lag, if the player's ping is high, and they seem to teleport around, the lastTime will take in account for that. Every tick that the player does not move, it will increase the expected by 0.8..., multiplying the amount of ticks not moving by the expected. This will also be handy for server lag and TPS drops, since micro time does not depend on the server. The check also checks for the player last movement, so if on the last tick the player's movement was legitimate, but the player lags and the movement is not legitimate, it will not mark the player.

Since the speed effect makes the player 20% faster then they already are, I multiplied the effect level multiplied by 0.2, multiplied by the original expected added by the original expected. I have tested this.

On Block Launcher, this worked and auto-banned me at VL 80.